### PR TITLE
feat(oas): --keep-field-names — preserve upstream field/param spellings

### DIFF
--- a/src/cli/oas.ts
+++ b/src/cli/oas.ts
@@ -164,6 +164,11 @@ program
   .option('--skip-optional-args', 'Skip optional arguments in queries', false)
   .option('--skip-optional-markers', 'Skip the "?" optional-field markers in selections', false)
   .option(
+    '--keep-field-names',
+    'Keep upstream field/param spellings (no camelCasing) when they are already valid GraphQL identifiers',
+    false,
+  )
+  .option(
     '--service-prefix <name>',
     'Prefix every type with "<Name>_" and every root field with "<name>_", so separately generated connectors compose without colliding',
     parseServicePrefix,

--- a/src/oas/oasContext.ts
+++ b/src/oas/oasContext.ts
@@ -41,6 +41,7 @@ export type GenerateOptions = {
   mapper?: Mapper;
   skipOptionalArgs?: boolean;
   skipOptionalMarkers?: boolean; // skip '?' marker
+  keepFieldNames?: boolean; // keep upstream field/param spellings when already valid identifiers
   servicePrefix?: string; // prefix every type and root field with the service name
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;

--- a/src/oas/oasGen.ts
+++ b/src/oas/oasGen.ts
@@ -27,6 +27,7 @@ interface IGenOptions {
   mapper?: Mapper;
   skipOptionalArgs?: boolean;
   skipOptionalMarkers?: boolean;
+  keepFieldNames?: boolean;
   servicePrefix?: string;
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;
@@ -132,6 +133,7 @@ export class OasGen {
   constructor(parser: Oas, options: GenerateOptions) {
     this.parser = parser;
     this.options = options;
+    Naming.keepOriginalNames = options.keepFieldNames === true;
     this.collector = new TypesCollector(this);
   }
 

--- a/src/oas/utils/naming.ts
+++ b/src/oas/utils/naming.ts
@@ -140,6 +140,9 @@ export class Naming {
   private static readonly RESERVED_ROOT_TYPE_NAMES = new Set(['Query', 'Mutation', 'Subscription']);
 
   public static genParamName(param: string): string {
+    if (Naming.keepsOwnSpelling(param || '')) {
+      return param;
+    }
     // Split on any run of non-alphanumeric characters, camelCase the parts, then
     // guarantee a valid GraphQL identifier: non-empty and not starting with a digit.
     // (Plain `[-_.]` splitting let spaces, `$`, `%`, … and leading digits through.)
@@ -177,8 +180,21 @@ export class Naming {
     return Naming.RESERVED_ROOT_TYPE_NAMES.has(identifier) ? identifier + 'Type' : identifier;
   }
 
+  // When set (option keepFieldNames / --keep-field-names), fields and params that are already
+  // valid GraphQL identifiers keep the upstream API's own spelling instead of being camelCased.
+  // Rationale (benchmarked): renamed fields no longer match the API vernacular in callers' priors
+  // and docs, so agentic callers introspect response types just to learn the new spellings.
+  public static keepOriginalNames = false;
+
+  private static keepsOwnSpelling(name: string): boolean {
+    return Naming.keepOriginalNames && /^[_A-Za-z][_0-9A-Za-z]*$/.test(name) && !/^(null|true|false)$/.test(name);
+  }
+
   public static sanitiseField(name: string): string {
     const fieldName = name.startsWith('@') ? name.substring(1) : name;
+    if (Naming.keepsOwnSpelling(fieldName)) {
+      return fieldName;
+    }
     return Naming.FIELD_CONVERTER.convert(fieldName);
   }
 
@@ -186,7 +202,8 @@ export class Naming {
   //   e.g. (trello) foo_bar with writtenAs fooBar2 -> `foo_bar: fooBar2`
   public static sanitiseFieldForSelect(name: string, isInput: boolean = false, writtenAs?: string): string {
     const fieldName = name.startsWith('@') ? name.substring(1) : name;
-    const sanitised = writtenAs ?? Naming.FIELD_CONVERTER.convert(fieldName);
+    const sanitised =
+      writtenAs ?? (Naming.keepsOwnSpelling(fieldName) ? fieldName : Naming.FIELD_CONVERTER.convert(fieldName));
 
     // The JSON key is already a valid identifier identical to the field — no alias needed.
     if (sanitised === name) {


### PR DESCRIPTION
Adds `--keep-field-names`: when a field or parameter name is already a valid GraphQL identifier, keep the upstream API's own spelling instead of camelCasing. Aliases and mapping indirection disappear — selections and bodies become identity mappings. Names that are not valid identifiers still go through the converter chain unchanged.

**Benchmark evidence**: renamed fields no longer match the API vernacular in agents' priors and task context, so agents introspect response types just to learn spellings (`accessToken` vs `access_token`) — 59 auth-token-response introspections per 57 tasks (opus) in a class of call absent from the snake_case baseline arm, and `Cannot query field` errors rose 304 → 433. Also unblocks `--infer-entity-resolvers` on snake_case APIs (see the last PR in this stack): R1's `@key`/`$this` names are spec-side and mismatch camelized fields.

Independent, single-commit PR — merges standalone (any overlap with the sibling PRs #5/#7/#8 is adjacent-line options plumbing that resolves trivially in merge order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
