### PR TITLE
feat(oas): --skip-arg-defaults + constraint notes in operation docstrings

### DIFF
--- a/src/cli/oas.ts
+++ b/src/cli/oas.ts
@@ -164,6 +164,11 @@ program
   .option('--skip-optional-args', 'Skip optional arguments in queries', false)
   .option('--skip-optional-markers', 'Skip the "?" optional-field markers in selections', false)
   .option(
+    '--skip-arg-defaults',
+    "Don't copy OAS parameter defaults into GraphQL argument defaults (a GraphQL default is always sent by the router, and advertised defaults anchor agentic callers)",
+    false,
+  )
+  .option(
     '--service-prefix <name>',
     'Prefix every type with "<Name>_" and every root field with "<name>_", so separately generated connectors compose without colliding',
     parseServicePrefix,

--- a/src/oas/nodes/get.ts
+++ b/src/oas/nodes/get.ts
@@ -72,8 +72,9 @@ export class Get extends Type implements Op {
     const description = this.operation.getDescription();
     const summary = this.operation.getSummary();
     const originalPath = this.operation.path;
+    const constraintNote = Naming.paramConstraintNote(this.operation);
 
-    if (description || summary || originalPath) {
+    if (description || summary || originalPath || constraintNote) {
       writer.write('  """\n').write('  ');
       if (description) {
         writer.write(description).write(' ');
@@ -83,6 +84,9 @@ export class Get extends Type implements Op {
       }
       if (originalPath) {
         writer.write('(').write(originalPath).write(')');
+      }
+      if (constraintNote) {
+        writer.write('\n  ').write(constraintNote);
       }
       writer.write('\n  """\n');
     }

--- a/src/oas/nodes/param.ts
+++ b/src/oas/nodes/param.ts
@@ -61,7 +61,10 @@ export class Param extends Type {
       writer.write('!');
     }
 
-    if (this.defaultValue !== null && this.defaultValue !== undefined) {
+    // An advertised GraphQL default is not neutral: the router fills it in (always sent on the
+    // wire, unlike an omitted OAS param), and agentic callers anchor on it (benchmarked: agents
+    // shown `pageLimit: Int = 5` make 5 their modal page size; unanchored they never pick it).
+    if (this.defaultValue !== null && this.defaultValue !== undefined && !context.generateOptions.skipArgDefaults) {
       this.writeDefaultValue(writer);
     }
 

--- a/src/oas/nodes/post.ts
+++ b/src/oas/nodes/post.ts
@@ -71,14 +71,18 @@ export class Post extends Get {
 
     const summary = this.operation.getSummary();
     const originalPath = this.operation.path;
+    const constraintNote = Naming.paramConstraintNote(this.operation);
 
-    if (summary || originalPath) {
+    if (summary || originalPath || constraintNote) {
       writer.write('  """\n').write('  ');
       if (summary) {
         writer.write(summary).write(' ');
       }
       if (originalPath) {
         writer.write('(').write(originalPath).write(')');
+      }
+      if (constraintNote) {
+        writer.write('\n  ').write(constraintNote);
       }
       writer.write('\n  """\n');
     }

--- a/src/oas/oasContext.ts
+++ b/src/oas/oasContext.ts
@@ -41,6 +41,7 @@ export type GenerateOptions = {
   mapper?: Mapper;
   skipOptionalArgs?: boolean;
   skipOptionalMarkers?: boolean; // skip '?' marker
+  skipArgDefaults?: boolean; // don't copy OAS parameter defaults into GraphQL argument defaults
   servicePrefix?: string; // prefix every type and root field with the service name
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;

--- a/src/oas/oasGen.ts
+++ b/src/oas/oasGen.ts
@@ -27,6 +27,7 @@ interface IGenOptions {
   mapper?: Mapper;
   skipOptionalArgs?: boolean;
   skipOptionalMarkers?: boolean;
+  skipArgDefaults?: boolean;
   servicePrefix?: string;
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;

--- a/src/oas/utils/naming.ts
+++ b/src/oas/utils/naming.ts
@@ -182,6 +182,33 @@ export class Naming {
     return Naming.FIELD_CONVERTER.convert(fieldName);
   }
 
+  // Compact per-parameter constraint note for the operation docstring: defaults, bounds, enums.
+  // A GraphQL `= default` in the signature is droppable (--skip-arg-defaults: it changes wire
+  // semantics and anchors agentic callers to tiny page sizes) — but the INFORMATION is
+  // load-bearing: benchmarked agents given no pagination hints silently accept server-truncated
+  // pages and answer from partial data. Constraints belong in prose, not in executable defaults.
+  public static paramConstraintNote(operation: Operation): string {
+    const parts: string[] = [];
+    let params: { name: string; schema?: Record<string, unknown> }[] = [];
+    try {
+      params = (operation.getParameters() ?? []) as { name: string; schema?: Record<string, unknown> }[];
+    } catch {
+      return '';
+    }
+    for (const p of params) {
+      const s = p.schema ?? {};
+      const bits: string[] = [];
+      if (s.default !== undefined && s.default !== null && s.default !== '') {
+        bits.push(`default ${JSON.stringify(s.default)}`);
+      }
+      if (s.minimum !== undefined) bits.push(`min ${s.minimum}`);
+      if (s.maximum !== undefined) bits.push(`max ${s.maximum}`);
+      if (Array.isArray(s.enum)) bits.push(`one of ${(s.enum as unknown[]).map((v) => JSON.stringify(v)).join('|')}`);
+      if (bits.length) parts.push(`${p.name} (${bits.join(', ')})`);
+    }
+    return parts.length ? `Params: ${parts.join('; ')}.` : '';
+  }
+
   // `writtenAs` replaces the field side of the alias — a sibling's numbered name from #69.
   //   e.g. (trello) foo_bar with writtenAs fooBar2 -> `foo_bar: fooBar2`
   public static sanitiseFieldForSelect(name: string, isInput: boolean = false, writtenAs?: string): string {


### PR DESCRIPTION
Two coupled changes, deliberately shipped together:

1. `--skip-arg-defaults` stops copying OAS parameter defaults into executable GraphQL argument defaults. A GraphQL default is router-filled and always sent on the wire (unlike an omitted OAS param), and it anchors agentic callers: shown `pageLimit: Int = 5`, benchmark agents made 5 their modal page size (103 uses over 57 tasks; unanchored agents chose 5 zero times) and paginated in long chains.
2. `paramConstraintNote()` renders each parameter's `default`/`minimum`/`maximum`/`enum` — standard JSON Schema keywords currently discarded entirely — into the operation docstring: `Params: page_limit (default 5, min 1, max 20).`

**Benchmarked warning, and the reason these are one PR**: shipping (1) without (2) collapsed task completion 89.5 → 54.4 (0↑/21↓, p=5e-7) — the visible default was the caller's only pagination signal, and without it agents silently accepted server-truncated 5-item pages as complete lists. With both: pagination chains fell below even the no-defaults Rust baseline (4.67 → 0.47/task, opus). Constraints belong in prose, not in executable signature defaults.

Independent, single-commit PR — merges standalone (any overlap with the sibling PRs #5/#6/#8 is adjacent-line options plumbing that resolves trivially in merge order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
