### PR TITLE
fix(oas): rewrite snake_case path params to $this in entity resolvers

### DIFF
--- a/src/oas/nodes/obj.ts
+++ b/src/oas/nodes/obj.ts
@@ -175,7 +175,7 @@ export class Obj extends Type {
     const i6 = ' '.repeat(6);
 
     // Rewrite each {param} to {$this.param} (vs {$args.param} for Query-field connectors).
-    const path = resolver.path.replace(/\{([a-zA-Z0-9]+)\}/g, '{$this.$1}');
+    const path = resolver.path.replace(/\{([a-zA-Z0-9_]+)\}/g, '{$this.$1}');
 
     writer
       .write('\n')


### PR DESCRIPTION
The R1 `$this` rewrite regex `\{([a-zA-Z0-9]+)\}` (obj.ts) has no underscore, so any snake_case path param (`{album_id}`, `{song_id}`, …) is left as a bare template and every inferred entity resolver fails composition with `INVALID_URL: 'album_id' must start with $this…`. `--infer-entity-resolvers` has therefore never composed against snake_case REST APIs.

One-character fix: add `_` to the character class. Verified: composition succeeds on a 10-service snake_case corpus that previously failed on every entity.

Related note: under default camelCasing the emitted `@key`/`$this` names (spec-side, e.g. `album_id`) then mismatch the renamed GraphQL fields (`albumId`) — pairing with `--keep-field-names` (earlier in this stack) composes cleanly; sanitizing R1's emitted names would be the standalone alternative.

Independent, single-commit PR — merges standalone. Pairs naturally with #6 (--keep-field-names) per the note above, but has no code dependency on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
