### PR TITLE
feat: --doc-pagination notes that a full page is not necessarily the last page

### DIFF
--- a/src/cli/oas.ts
+++ b/src/cli/oas.ts
@@ -101,6 +101,7 @@ async function main(sourceFile: string, opts: OptionValues): Promise<void> {
     skipArgDefaults: opts.skipArgDefaults,
     keepFieldNames: opts.keepFieldNames,
     docResponseFields: opts.docResponseFields,
+    docPagination: opts.docPagination,
     servicePrefix: opts.servicePrefix,
     inferEntityResolvers: opts.inferEntityResolvers,
     skipAuth: opts.skipAuth,
@@ -181,6 +182,10 @@ program
     '--doc-response-fields',
     'Add each operation\'s top-level response field names as a "Returns: ..." note on the operation',
     false,
+  )
+  .option(
+    '--doc-pagination',
+    'Note on every operation with pagination parameters that a full page is not necessarily the last page',
   )
   .option(
     '--service-prefix <name>',

--- a/src/oas/nodes/get.ts
+++ b/src/oas/nodes/get.ts
@@ -81,8 +81,9 @@ export class Get extends Type implements Op {
     const jsonReason = this.resultJsonReason(selection, keep);
     const paramsLine = this.paramsDocLine(context);
     const responseFieldsLine = this.responseFieldsDocLine(context, selection);
+    const paginationLine = this.paginationDocLine(context);
 
-    if (description || summary || originalPath || jsonReason || paramsLine || responseFieldsLine) {
+    if (description || summary || originalPath || jsonReason || paramsLine || responseFieldsLine || paginationLine) {
       writer.write('  """\n').write('  ');
       if (description) {
         writer.write(description).write(' ');
@@ -101,6 +102,10 @@ export class Get extends Type implements Op {
       }
       if (responseFieldsLine) {
         writer.write('\n\n  ').write(responseFieldsLine);
+      }
+      if (paginationLine) {
+        // ride the "Returns ..." paragraph when there is one — the note completes that sentence
+        writer.write(responseFieldsLine ? '\n  ' : '\n\n  ').write(paginationLine);
       }
       writer.write('\n  """\n');
     }
@@ -153,6 +158,28 @@ export class Get extends Type implements Op {
       .filter((note): note is string => note !== undefined);
 
     return notes.length > 0 ? `Params: ${notes.join(', ')}` : undefined;
+  }
+
+  // Builds the pagination note --doc-pagination adds to an operation's description, when any
+  // parameter's name carries a "page" token or is exactly "cursor"/"offset". A page-sized
+  // response otherwise reads as complete, so the note says the one thing the signature can't:
+  // a full page is not necessarily the last page. see docs/FIXED.md #170
+  //   e.g. (doc-pagination.yaml) get:/items(page_index, page_limit) -> "Returns one page of
+  //   results; a full page is not necessarily the last page."
+  protected paginationDocLine(context: OasContext): string | undefined {
+    if (!context.generateOptions?.docPagination) {
+      return undefined;
+    }
+
+    const paginates = this.params.some((param) => {
+      const tokens = param.name
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .toLowerCase()
+        .split(/[^a-z0-9]+/);
+      return tokens.includes('page') || param.name.toLowerCase() === 'cursor' || param.name.toLowerCase() === 'offset';
+    });
+
+    return paginates ? 'Returns one page of results; a full page is not necessarily the last page.' : undefined;
   }
 
   // Builds the "Returns:" line --doc-response-fields adds to an operation's description, naming

--- a/src/oas/oasContext.ts
+++ b/src/oas/oasContext.ts
@@ -55,6 +55,14 @@ export type GenerateOptions = {
   // #158: keep a spec field/param spelling verbatim when it already reads safely as both a
   // GraphQL name and a bare connector-selection key, instead of always camelCasing it.
   keepFieldNames?: boolean;
+  // #170: note on every paginated operation that a full page is not necessarily the last
+  // page, so a reader doesn't treat one page as the complete result set. An operation is
+  // paginated when any parameter's name carries a "page" token (page_index, pageLimit,
+  // per_page, ...) or is exactly "cursor" or "offset".
+  //   e.g. (doc-pagination.yaml) get:/items with page_index/page_limit gains the description
+  //   line "Returns one page of results; a full page is not necessarily the last page."
+  docPagination?: boolean;
+
   // #160: add each operation's response field names to its description as a "Returns:" line,
   // so a reader can see what a request actually hands back without making the request first.
   //   e.g. GET /items/{item_id} answering { id, name, created_at } gets the extra description

--- a/src/oas/oasGen.ts
+++ b/src/oas/oasGen.ts
@@ -91,6 +91,8 @@ interface IGenOptions {
   skipArgDefaults?: boolean;
   keepFieldNames?: boolean;
   docResponseFields?: boolean;
+  // #170: note on paginated operations that a full page is not necessarily the last page
+  docPagination?: boolean;
   servicePrefix?: string;
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;

--- a/src/tests/runners.ts
+++ b/src/tests/runners.ts
@@ -27,6 +27,7 @@ export async function runOasTest(
     skipArgDefaults?: boolean;
     keepFieldNames?: boolean;
     docResponseFields?: boolean;
+    docPagination?: boolean;
     inferEntityResolvers?: boolean;
     baseURL?: string;
     overrides?: OverridesConfig;
@@ -64,6 +65,7 @@ export async function runOasTest(
     skipOptionalMarkers: opts.skipOptionalMarkers,
     keepFieldNames: opts.keepFieldNames,
     docResponseFields: opts.docResponseFields,
+    docPagination: opts.docPagination,
     inferEntityResolvers: opts.inferEntityResolvers,
     emitConnectorErrors: opts.emitConnectorErrors,
     skipAuth: opts.skipAuth,

--- a/tests/all/doc-pagination.test.ts
+++ b/tests/all/doc-pagination.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { runOasTest } from '../../src/tests/runners.js';
+import './_setup.js';
+
+// #170: --doc-pagination notes on every paginated operation that a full page is not necessarily
+// the last page. Without the note, a page-sized response reads as the complete result set and a
+// reader silently accepts truncated data. An operation counts as paginated when any parameter's
+// name carries a "page" token (page_index, pageLimit, per_page, ...) or is exactly "cursor" or
+// "offset" — the signature can show the parameters, but not what a full page means.
+
+const NOTE = 'Returns one page of results; a full page is not necessarily the last page.';
+const PATHS = ['get:/items', 'get:/events', 'get:/pages', 'get:/items/{item_id}'];
+
+const run = (opts: { docPagination?: boolean; docResponseFields?: boolean } = {}) =>
+  runOasTest('doc-pagination.yaml', PATHS, 4, 1, { skipValidation: true, keepFieldNames: true, ...opts });
+
+test('test_170_disabled_by_default', async () => {
+  const schema = await run();
+  assert.ok(!schema!.includes(NOTE), 'no pagination note without the flag');
+});
+
+test('test_170_page_params_gain_the_note', async () => {
+  const schema = await run({ docPagination: true });
+  // get:/items paginates via page_index/page_limit
+  const items = schema!.slice(schema!.indexOf('List items'), schema!.indexOf('listItems'));
+  assert.ok(items.includes(NOTE), 'page_index/page_limit op carries the note');
+  // get:/events paginates via cursor
+  const events = schema!.slice(schema!.indexOf('List events'), schema!.indexOf('listEvents'));
+  assert.ok(events.includes(NOTE), 'cursor op carries the note');
+});
+
+test('test_170_non_paginated_ops_stay_silent', async () => {
+  const schema = await run({ docPagination: true });
+  // get:/pages has no pagination parameters — "pages" in the name alone must not trigger
+  const pages = schema!.slice(schema!.indexOf('List pages of the document'), schema!.indexOf('listPages'));
+  assert.ok(!pages.includes(NOTE), 'an op merely named "pages" does not get the note');
+  const byId = schema!.slice(schema!.indexOf('Get an item'), schema!.indexOf('getItem'));
+  assert.ok(!byId.includes(NOTE), 'a by-id op does not get the note');
+});
+
+test('test_170_rides_the_returns_paragraph', async () => {
+  // with --doc-response-fields on, the note completes the "Returns a list of items with:"
+  // paragraph instead of opening its own
+  const schema = await run({ docPagination: true, docResponseFields: true });
+  assert.ok(
+    schema!.includes(`item_id, name\n  ${NOTE}`),
+    'note sits on the line after the Returns line, same paragraph',
+  );
+});

--- a/tests/resources/oas/doc-pagination.yaml
+++ b/tests/resources/oas/doc-pagination.yaml
@@ -1,0 +1,77 @@
+openapi: 3.0.0
+info:
+  title: Doc pagination
+  version: 1.0.0
+servers:
+  - url: http://localhost:9000
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items
+      parameters:
+        - name: page_index
+          in: query
+          schema: { type: integer, default: 0, minimum: 0 }
+        - name: page_limit
+          in: query
+          schema: { type: integer, default: 5, minimum: 1, maximum: 20 }
+      responses:
+        '200':
+          description: a page of items
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Item' }
+  /events:
+    get:
+      operationId: listEvents
+      summary: List events
+      parameters:
+        - name: cursor
+          in: query
+          schema: { type: string }
+      responses:
+        '200':
+          description: a page of events
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Item' }
+  /pages:
+    get:
+      operationId: listPages
+      summary: List pages of the document
+      # no pagination parameters: "pages" in the path/name alone must not trigger the note
+      responses:
+        '200':
+          description: every page
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Item' }
+  /items/{item_id}:
+    get:
+      operationId: getItem
+      summary: Get an item
+      parameters:
+        - name: item_id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: one item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Item' }
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        item_id: { type: integer }
+        name: { type: string }


### PR DESCRIPTION
## Problem

A paginated operation's signature shows its page parameters, but not what a full page *means*. When a caller receives exactly page-size results, nothing in the schema says there may be more — so a reader treats one page as the complete result set and silently accepts truncated data. This is the same knowledge-placement gap as #159/#160: the information exists (the operation paginates), but nowhere a reader actually looks.

## Change

New `--doc-pagination` flag. Every operation with pagination parameters gains one description line:

> Returns one page of results; a full page is not necessarily the last page.

An operation counts as paginated when any parameter's name carries a `page` token after snake/camel splitting (`page_index`, `pageLimit`, `per_page`, `page_size`, …) or is exactly `cursor` or `offset`. Purely signature-driven — no per-API or per-field knowledge. An operation merely *named* pages (`GET /pages`, no page params) does not trigger.

When `--doc-response-fields` is also on, the note completes the "Returns …" paragraph rather than opening its own; otherwise it stands alone. Flag off: output byte-identical.

## Evidence

On the AppWorld benchmark (same harness as #5–#10): a 9-task slice of tasks failing on silent page truncation. Adding this note to the schema flipped the task family whose failures were purely pagination from 1/3 to 3/3. Control experiment worth reporting: delivering the *identical sentence* through agent prompt instructions instead of the schema produced *identical* results — the docstring placement loses nothing over prompt engineering, and it travels with the schema to every consumer instead of one harness.

The flag reproduces the hand-validated benchmark tree exactly: 69 operations across the 10-app corpus, per-app identical placement.

## Tests

`tests/all/doc-pagination.test.ts` (+ fixture): off-by-default, page-token and cursor triggers, no false trigger on page-like names or by-id ops, and paragraph placement with `--doc-response-fields`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)