### PR TITLE
fix: entity connectors authenticate like the op they were inferred from

### DIFF
--- a/src/oas/io/writer.ts
+++ b/src/oas/io/writer.ts
@@ -14,6 +14,7 @@ import _ from 'lodash';
 export class Writer {
   private schemaWriter: SchemaWriter;
   private operationWriter: OperationWriter;
+  private security: SecurityPlan;
   public buffer: string[];
 
   constructor(public gen: OasGen) {
@@ -21,12 +22,12 @@ export class Writer {
     // resolve the spec's security once (schemes, global requirement, per-op mode) and share it —
     // schemaWriter (@source) and operationWriter (per-@connect) both query it instead of re-walking
     // the whole spec per operation.
-    const security = SecurityPlan.from(gen.parser, {
+    this.security = SecurityPlan.from(gen.parser, {
       skipAuth: gen.options.skipAuth,
       authValuePrefix: gen.options.authValuePrefix,
     });
-    this.schemaWriter = new SchemaWriter(gen, security);
-    this.operationWriter = new OperationWriter(gen, security);
+    this.schemaWriter = new SchemaWriter(gen, this.security);
+    this.operationWriter = new OperationWriter(gen, this.security);
   }
 
   public write(input: string): Writer {
@@ -60,7 +61,7 @@ export class Writer {
     // Attach entity resolvers onto the (single, canonical) collected type instances the
     // loop below generates, so each entity type can emit @key + its type-level
     // @connect/$this resolver. Resets first, so it's a no-op when the flag is off.
-    inferEntityResolvers(context, this.gen, types, selection);
+    inferEntityResolvers(context, this.gen, types, selection, this.security);
 
     // #161: key-only reference fields on other types pointing at an R1-resolved entity — reads
     // the resolvers just attached above, so it runs right after.

--- a/src/oas/nodes/entity.ts
+++ b/src/oas/nodes/entity.ts
@@ -1,4 +1,5 @@
 import { IType, Obj, Prop, PropEntityLink, Res, T } from './internal.js';
+import type { NameValue, SecurityPlan } from '../io/security.js';
 import { Naming } from '../utils/naming.js';
 import { OasContext } from '../oasContext.js';
 import { OasGen } from '../oasGen.js';
@@ -23,6 +24,10 @@ export interface EntityResolver {
   source: string;
   /** R6: set on a batch resolver — same @key/selection, but $batch instead of $this. */
   batch?: BatchSpec;
+  /** The qualifying op's per-@connect auth header (per-op security mode only), if any. */
+  headerAuth?: NameValue | null;
+  /** The qualifying op's apiKey-in-query auth (any mode — @source has no queryParams), if any. */
+  queryAuth?: NameValue | null;
 }
 
 /** R6: the batch `@connect` spec attached to a resolver — built by `applyBatchResolvers`. */
@@ -80,6 +85,7 @@ export function inferEntityResolvers(
   gen: OasGen,
   types: Map<string, IType>,
   selection: string[],
+  security?: SecurityPlan,
 ): void {
   // Reset on the canonical (generated) type instances so a re-run can't leak resolvers.
   for (const type of types.values()) {
@@ -127,6 +133,14 @@ export function inferEntityResolvers(
       continue;
     }
 
+    // The resolver must authenticate exactly like the op it was inferred from: in uniform
+    // mode the @source header already covers it, but a per-op header or an apiKey-in-query
+    // credential lives on each @connect — without it, every router-side entity fetch to a
+    // protected endpoint fails. Resolved here because the plan lives with the writer; the
+    // writer resolves the same op again for its Query field, so dropped-scheme warnings can
+    // repeat for an op that is both selected and a resolver.
+    const { header: headerAuth, query: queryAuth } = security?.forOp(op) ?? { header: null, query: null };
+
     // Composite key for this resolver: path-param names in path order, single-space
     // joined (e.g. "id" or "orgId id"). Each qualifying op is one type-level resolver.
     target.entityResolvers.push({
@@ -134,6 +148,8 @@ export function inferEntityResolvers(
       path: op.operation.path,
       verb: op.verb,
       source: 'api',
+      headerAuth,
+      queryAuth,
     });
   }
 }

--- a/src/oas/nodes/obj.ts
+++ b/src/oas/nodes/obj.ts
@@ -197,10 +197,39 @@ export class Obj extends Type {
       .write('@connect(\n')
       .write(i6)
       .write(`source: "${resolver.source}"\n`)
-      .write(i6)
-      .write(`http: { ${resolver.verb}: "${path}" }\n`)
-      .write(i6)
-      .write('selection: """\n');
+      .write(i6);
+
+    // The op this resolver was inferred from may carry per-@connect auth (a per-op-mode header,
+    // or apiKey-in-query in any mode — @source has no queryParams). Without it the router-side
+    // entity fetch hits the protected endpoint unauthenticated. Same emission shape as an op
+    // connector's requestMethod; uniform-mode header auth stays on @source and is not repeated.
+    if (resolver.headerAuth || resolver.queryAuth) {
+      const i8 = ' '.repeat(8);
+      writer.write('http: {\n').write(i8).write(`${resolver.verb}: "${path}"\n`);
+      if (resolver.queryAuth) {
+        writer
+          .write(i8)
+          .write('queryParams: """\n')
+          .write(' '.repeat(10))
+          .write(`"${resolver.queryAuth.name}": ${resolver.queryAuth.value}\n`)
+          .write(i8)
+          .write('"""\n');
+      }
+      if (resolver.headerAuth) {
+        writer
+          .write(i8)
+          .write('headers: [{ name: "')
+          .write(resolver.headerAuth.name)
+          .write('", value: "')
+          .write(resolver.headerAuth.value)
+          .write('" }]\n');
+      }
+      writer.write(i6).write('}\n');
+    } else {
+      writer.write(`http: { ${resolver.verb}: "${path}" }\n`);
+    }
+
+    writer.write(i6).write('selection: """\n');
 
     // Base the selection at 6 spaces like a Query connector. `select` adds
     // `context.stack.length` (this object is mid-generation on the stack), so subtract it.

--- a/tests/all/entity-auth.test.ts
+++ b/tests/all/entity-auth.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { runOasTest } from '../../src/tests/runners.js';
+import './_setup.js';
+
+// #171: a type-level entity resolver must authenticate exactly like the operation it was
+// inferred from. Uniform-mode header auth already covers it via @source, but a per-op-mode
+// header or an apiKey-in-query credential lives on each @connect — before this fix the
+// inferred entity connector emitted neither, so every router-side entity fetch to a
+// protected endpoint went out unauthenticated.
+
+const PATHS = ['get:/items', 'get:/items/{item_id}'];
+
+const run = (file: string) =>
+  runOasTest(file, PATHS, 2, 1, { skipValidation: true, keepFieldNames: true, inferEntityResolvers: true });
+
+// slice from the entity type's @key through its selection — the type-level connector only
+const entityConnector = (schema: string) => {
+  const start = schema.indexOf('type Item @key');
+  assert.ok(start >= 0, 'entity resolver was inferred');
+  return schema.slice(start, schema.indexOf('{', schema.indexOf('selection:', start)));
+};
+
+test('test_171_per_op_header_rides_the_entity_connector', async () => {
+  // the by-id GET declares its own bearer security (per-op mode: nothing on @source)
+  const schema = await run('entity-auth.yaml');
+  assert.ok(
+    !schema!.includes('@source(name: "api", http: { baseURL: "http://localhost:9000", headers'),
+    'per-op mode: no auth on @source',
+  );
+  const connector = entityConnector(schema!);
+  assert.ok(
+    connector.includes('headers: [{ name: "Authorization", value: "Bearer {$config.token}" }]'),
+    "entity connector carries the by-id op's bearer header",
+  );
+});
+
+test('test_171_query_auth_rides_the_entity_connector', async () => {
+  // global apiKey-in-query: @source has no queryParams, so the credential must sit per-@connect
+  const schema = await run('entity-auth-query.yaml');
+  const connector = entityConnector(schema!);
+  assert.ok(connector.includes('"api_key": $config.apiKey'), 'entity connector carries the apiKey query credential');
+  assert.ok(!connector.includes('headers:'), 'no header auth for a query-only scheme');
+});
+
+test('test_171_uniform_header_stays_on_source', async () => {
+  // global bearer: the @source header covers every connector — the entity connector must stay
+  // in its compact form, not repeat the credential
+  const schema = await run('entity-auth-uniform.yaml');
+  assert.ok(
+    schema!.includes('headers: [{ name: "Authorization", value: "Bearer {$config.token}" }] })'),
+    'uniform mode: auth header on @source',
+  );
+  const connector = entityConnector(schema!);
+  assert.ok(
+    connector.includes('http: { GET: "/items/{$this.item_id}" }'),
+    'entity connector keeps the compact http form',
+  );
+  assert.ok(!connector.includes('headers:'), 'credential not repeated on the entity connector');
+});

--- a/tests/resources/oas/entity-auth-query.yaml
+++ b/tests/resources/oas/entity-auth-query.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.0
+info:
+  title: Entity auth query
+  version: 1.0.0
+servers:
+  - url: http://localhost:9000
+security:
+  - apiKeyAuth: []
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items
+      responses:
+        '200':
+          description: items
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Item' }
+  /items/{item_id}:
+    get:
+      operationId: getItem
+      summary: Get an item
+      parameters:
+        - name: item_id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: one item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Item' }
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: query
+      name: api_key
+  schemas:
+    Item:
+      type: object
+      properties:
+        item_id: { type: integer }
+        name: { type: string }

--- a/tests/resources/oas/entity-auth-uniform.yaml
+++ b/tests/resources/oas/entity-auth-uniform.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  title: Entity auth uniform
+  version: 1.0.0
+servers:
+  - url: http://localhost:9000
+security:
+  - bearerAuth: []
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items
+      responses:
+        '200':
+          description: items
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Item' }
+  /items/{item_id}:
+    get:
+      operationId: getItem
+      summary: Get an item
+      parameters:
+        - name: item_id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: one item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Item' }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Item:
+      type: object
+      properties:
+        item_id: { type: integer }
+        name: { type: string }

--- a/tests/resources/oas/entity-auth.yaml
+++ b/tests/resources/oas/entity-auth.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.0
+info:
+  title: Entity auth
+  version: 1.0.0
+servers:
+  - url: http://localhost:9000
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items
+      # no security: with the by-id op below declaring its own, the spec is in per-op mode
+      responses:
+        '200':
+          description: items
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Item' }
+  /items/{item_id}:
+    get:
+      operationId: getItem
+      summary: Get an item
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: item_id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: one item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Item' }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Item:
+      type: object
+      properties:
+        item_id: { type: integer }
+        name: { type: string }


### PR DESCRIPTION
## Problem

`--infer-entity-resolvers` builds a type-level resolver from a GET-by-key operation, but `writeEntityConnector` emitted a bare `http: { GET: "..." }` — no headers, no query credential. The generator's auth model has two placements:

- **Uniform mode** (one spec-wide scheme): the header rides `@source`, so entity connectors were already covered.
- **Per-op mode** (any op declares its own `security`): headers live on each `@connect` — and apiKey-in-query credentials live per-`@connect` in *every* mode, since `SourceHTTP` has no `queryParams`.

In both of those cases the inferred entity connector carried nothing, so every router-side entity fetch to a protected endpoint went out unauthenticated and failed.

## Fix

Resolve the qualifying operation's per-`@connect` auth (`SecurityPlan.forOp`) at inference time, carry it on the `EntityResolver`, and emit it in `writeEntityConnector` with the same shape an operation connector uses:

```graphql
type Item @key(fields: "item_id")
  @connect(
    source: "api"
    http: {
      GET: "/items/{$this.item_id}"
      headers: [{ name: "Authorization", value: "Bearer {$config.token}" }]
    }
    selection: "..."
  )
```

Uniform-mode header auth stays on `@source` and is not repeated on the connector. With no per-`@connect` auth, the compact `http: { GET: "..." }` form is byte-identical to before. Batch resolvers (R6) are unchanged by this PR — they reuse the key resolver but fetch through their own op, so their auth is a separate (smaller) follow-up if wanted.

## Tests

`tests/all/entity-auth.test.ts` + three fixtures: per-op bearer rides the entity connector (and `@source` stays bare), apiKey-in-query rides it in uniform mode, and uniform bearer stays on `@source` with the connector byte-stable. Full suite: failure set identical to main (the pre-existing missing-fixture failures), zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)