### PR TITLE
feat(cli): expose --emit-connector-errors

### DIFF
--- a/src/cli/oas.ts
+++ b/src/cli/oas.ts
@@ -102,6 +102,7 @@ async function main(sourceFile: string, opts: OptionValues): Promise<void> {
     keepFieldNames: opts.keepFieldNames,
     docResponseFields: opts.docResponseFields,
     docPagination: opts.docPagination,
+    emitConnectorErrors: opts.emitConnectorErrors,
     servicePrefix: opts.servicePrefix,
     inferEntityResolvers: opts.inferEntityResolvers,
     skipAuth: opts.skipAuth,
@@ -186,6 +187,10 @@ program
   .option(
     '--doc-pagination',
     'Note on every operation with pagination parameters that a full page is not necessarily the last page',
+  )
+  .option(
+    '--emit-connector-errors',
+    "Emit an errors block mapping the documented error body's message and the HTTP status on operations that document 4xx/5xx responses",
   )
   .option(
     '--service-prefix <name>',


### PR DESCRIPTION
## Problem

The R4 errors feature — an `errors:` block mapping the documented error body's `message` field and the HTTP status onto connector failures — has been on the programmatic API since 0.12.0, but has no CLI flag, so command-line builds can never enable it. Without it the router collapses upstream 4xx/5xx bodies to an opaque `"Request failed"`.

The cost is measurable: in our AppWorld benchmark runs, an agent blind to `"The payment card has expired."` / `"Insufficient money in the Venmo balance."` guessed its way through recovery (a balance top-up with seven cascading side-effect record changes) and failed the task's audit; the same task passes in a harness that surfaces the message. Blind retries also inflate output tokens across the board.

## Change

Plumbing only: `--emit-connector-errors` on the CLI, mapped to the existing `emitConnectorErrors` option. The feature itself is unchanged and covered by the existing R4 tests.

Verified live on Apollo Router 2.14.0: with the flag on, a 422 that previously surfaced as `"Request failed"` returns the upstream body's message (`"Invalid time format. Use HH:MM."`) with `statusCode` in extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)