### PR TITLE
feat(cli): --skip-degrade-reasons leaves NEEDS ATTENTION notes out

### DIFF
--- a/docs/FIXED.md
+++ b/docs/FIXED.md
@@ -9883,3 +9883,53 @@ production-selection counts checked directly (all 19 `test_corpus_*` and all 9
 (`unwrapRedundantArrayItems`), `src/oas/io/writer.ts` (the write-budget the count gates),
 `src/oas/nodes/union.ts` (`consolidateMembers`, which lowers it), #182 (the inline case this
 completes), #186 (the three-copies-of-this-check cleanup this surfaced).
+## 188 [FEAT] · `--skip-degrade-reasons`: leave the "NEEDS ATTENTION" note out of agent-facing SDL — ✅ Fixed
+
+**Symptom:** the "NEEDS ATTENTION: ... defaulted to JSON" note gen writes into a field's own
+description is addressed to the schema author, but it rides straight into every consumer's copy of
+the SDL — an AppWorld agent benchmark found the note diluting the field's usage guidance right next
+to it. The author already gets the same reason as a build-time warning at its point of origin.
+
+**Example** (`degrade-reasons.yaml`):
+```yaml
+blob:
+  description: An opaque blob.
+  anyOf: [{ type: string }, { type: integer }, { type: number }]
+```
+- default (unchanged): `"""\n  An opaque blob.\n\n  NEEDS ATTENTION: ...\n  """\n  blob: JSON`
+- with the flag: `"An opaque blob."\n  blob: JSON` — no note, author text intact
+- a field whose own text already contains the literal words "NEEDS ATTENTION:" or an em-dash keeps
+  that text verbatim either way (dash-normalised to `--`, same as always) — only the *generated*
+  note is conditional.
+
+**Fix:** PR #13 (adamd-apollo, `fix/agent-facing-diagnostics`) first shipped this as
+`--strip-json-diagnostics`, a five-regex post-generation pass over the finished SDL text. Reworked
+to gate at the producer instead:
+- `Schemas.withJsonNote(context, schema, reason)` (`src/oas/utils/schemas.ts`) now reads
+  `context.generateOptions?.skipDegradeReasons === true` and skips appending the note; the author's
+  own description is still dash-normalised on both paths. No text pass, no regex.
+- `skipDegradeReasons?: boolean` threaded through `IGenOptions`/`GenerateOptions`/`runOasTest`
+  opts and `--skip-degrade-reasons` (next to the other `--skip-*` flags).
+- Replaces `stripJsonDiagnostics` end to end — one flag, not two.
+- The 16 existing `withJsonNote` call sites now pass `context`.
+- Five of them write the note text directly (`get.ts`, `post.ts`, `map.ts`, `param.ts`, `union.ts`'s
+  `writeMemberJsonNote`) and now check the *returned text* for presence, not the raw reason string,
+  so a note-only field opens no empty `"""\n  """` pair.
+- `context` threaded through `dedupedSelectedProps`, `hasSelectedProps`, `emptyMergeReason` and
+  `resultJsonReason` to reach `union.ts:278`'s incompatible-merged-field fallback.
+- PR #13's `stripInlineDiagnostics` (5 regexes) and its `--strip-json-diagnostics` flag deleted
+  outright — the producer gate replaces both halves of the old mechanism.
+- Not touched (separate issue): `factory.ts`'s two `warn(null, ...)` sites and `union.ts:277`'s
+  `warn(null, ...)` already have `context` in scope but don't use it, losing indentation in trace
+  output.
+
+**Verified:** `tests/all/degrade-reasons.test.ts` (renamed from PR #13's
+`strip-json-diagnostics.test.ts`) — two full-schema snapshot tests, not substrings: default output
+byte-identical to before the flag existed, and flag-on output has zero generated notes anywhere
+while the two fields whose own author text contains "NEEDS ATTENTION:"/an em-dash keep that text
+verbatim. `tests/all/oas-core.test.ts` green (222/222). `tsc --noEmit` clean, `eslint` clean.
+
+**Refs:** `src/oas/utils/schemas.ts` (`withJsonNote`), `src/oas/oasContext.ts`, `src/oas/oasGen.ts`,
+`src/cli/oas.ts`, `src/tests/runners.ts`, `src/oas/nodes/{factory,propObj,propArray,get,post,map,
+param,union,res}.ts`, `tests/resources/oas/degrade-reasons.yaml`, PR #13 (adamd-apollo): the
+motivating finding, fixture and first implementation.

--- a/readme.md
+++ b/readme.md
@@ -461,6 +461,7 @@ Note the `api_key` header: petstore declares an `apiKey` security scheme, which 
 - `--connector-spec-version <version>`: Connector spec version to use (default: `v0.4`, the only supported value).
 - `--skip-optional-args`: Skip optional arguments in queries (default: `false`).
 - `--skip-optional-markers`: Skip the `?` optional-field markers in selections (default: `false`).
+- `--skip-degrade-reasons`: Leave out the `NEEDS ATTENTION` note gen adds to every description it defaulted to `JSON` — for agent-facing SDL, where the note would dilute the description it rides on (default: `false`). The author still gets every note as a build-time warning at its point of origin.
 - `--base-url <url>`: Override the `@source` base URL (default: `servers[0]` from the spec).
 - `--overrides <file>`: Load per-operation request overrides from a JSON file, keyed by op id. See [Request overrides](#request-overrides).
 - `--batch <file>`: Load batch endpoints (op id -> `{ maxSize? }`) from a JSON file. See [Batch endpoints](#batch-endpoints).

--- a/src/cli/oas.ts
+++ b/src/cli/oas.ts
@@ -103,6 +103,7 @@ async function main(sourceFile: string, opts: OptionValues): Promise<void> {
     docResponseFields: opts.docResponseFields,
     docPagination: opts.docPagination,
     emitConnectorErrors: opts.emitConnectorErrors,
+    skipDegradeReasons: opts.skipDegradeReasons,
     servicePrefix: opts.servicePrefix,
     inferEntityResolvers: opts.inferEntityResolvers,
     skipAuth: opts.skipAuth,
@@ -172,6 +173,11 @@ program
   .option(
     '--skip-arg-defaults',
     'Write a parameter\'s default, minimum, maximum, and allowed values as a "Params: ..." note on the operation instead of writing the default straight into the argument',
+    false,
+  )
+  .option(
+    '--skip-degrade-reasons',
+    'Leave out the NEEDS ATTENTION note gen adds to every description it defaulted to JSON. For agent-facing SDL; warnings are always logged.',
     false,
   )
   .option(

--- a/src/oas/nodes/factory.ts
+++ b/src/oas/nodes/factory.ts
@@ -59,7 +59,7 @@ export class Factory {
       if (!schema) {
         const reason = `the reference '${ref}' doesn't point to anything in this API description — sent as raw JSON instead.`;
         warn(null, '[factory]', reason);
-        return new Scalar(parent, 'JSON', Schemas.withJsonNote(inputSchema as SchemaObject, reason), reason);
+        return new Scalar(parent, 'JSON', Schemas.withJsonNote(context, inputSchema as SchemaObject, reason), reason);
       }
     }
 
@@ -116,11 +116,11 @@ export class Factory {
       // e.g. a map value's `additionalProperties: { additionalProperties: false }` becomes JSON —
       // map.ts reads this reason back to note its own `value:` line. see docs/FIXED.md #155
       const reason = 'this object declares no properties of its own — sent as raw JSON instead.';
-      result = new Scalar(parent, 'JSON', Schemas.withJsonNote(schemaObj, reason), reason);
+      result = new Scalar(parent, 'JSON', Schemas.withJsonNote(context, schemaObj, reason), reason);
     }
     // scalar
     else {
-      result = this.createScalarType(schemaObj, parent, ref);
+      result = this.createScalarType(context, schemaObj, parent, ref);
     }
 
     // we could not infer a proper type
@@ -131,7 +131,7 @@ export class Factory {
     return result;
   }
 
-  private static createScalarType(schema: SchemaObject | null, parent: IType, ref?: string) {
+  private static createScalarType(context: OasContext, schema: SchemaObject | null, parent: IType, ref?: string) {
     const typeStr = schema?.type;
     if (typeStr != null) {
       if (typeStr === 'array') {
@@ -158,7 +158,7 @@ export class Factory {
       // when this is a whole response body (e.g. a get's 200 is `{ type: 'url' }` directly), the
       // reason above now also reaches the op's own docstring, not just the build log. see docs/FIXED.md #155
       const reason = `this schema's type '${typeStr}' has no GraphQL scalar equivalent — sent as raw JSON instead.`;
-      return new Scalar(parent, 'JSON', Schemas.withJsonNote(schema!, reason), reason);
+      return new Scalar(parent, 'JSON', Schemas.withJsonNote(context, schema!, reason), reason);
     } else if (schema?.enum != null) {
       if (!GqlUtils.isGqlEnum(schema)) {
         // same degrade as the site above; with no `type` at all, enum values read as strings. see docs/FIXED.md #172
@@ -404,7 +404,7 @@ export class Factory {
             const reason =
               'a oneOf of only plain scalar/enum values has no GraphQL union member to build — sent as raw JSON instead.';
             warn(context, '[factory]', reason);
-            prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(schemaObj, reason));
+            prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(context, schemaObj, reason));
           } else {
             const inner: PropComp = new PropComp(parent, propName, schemaObj);
             inner.comp = new Union(
@@ -427,7 +427,7 @@ export class Factory {
             const reason =
               "a map (object with arbitrary keys) can't be an input type in GraphQL — sent as raw JSON instead of a typed structure.";
             warn(context, '[factory]', reason);
-            prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(schemaObj, reason));
+            prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(context, schemaObj, reason));
           } else {
             // Map property: object with only additionalProperties
             const mapType: Map = new Map(parent, ref || propName, schemaObj);
@@ -486,7 +486,7 @@ export class Factory {
         const reason =
           'a oneOf of only plain scalar/enum values has no GraphQL union member to build — sent as raw JSON instead.';
         warn(context, '[factory]', reason);
-        prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(schemaObj, reason));
+        prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(context, schemaObj, reason));
       } else {
         const inner: PropComp = new PropComp(parent, propName, schemaObj);
         inner.comp = new Union(inner, ref || _.get(schemaObj, 'name'), schemaObj.oneOf as SchemaObject[]);
@@ -502,7 +502,7 @@ export class Factory {
         const reason =
           "a map (object with arbitrary keys) can't be an input type in GraphQL — sent as raw JSON instead of a typed structure.";
         warn(context, '[factory]', reason);
-        prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(schemaObj, reason));
+        prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(context, schemaObj, reason));
       } else {
         // Map property: object with only additionalProperties (no explicit type)
         const mapType: Map = new Map(parent, ref || propName, schemaObj);
@@ -517,7 +517,7 @@ export class Factory {
       const reason =
         "this field's shape didn't match any known pattern and defaulted to JSON — worth checking the source OAS schema.";
       warn(context, '[factory]', reason);
-      prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(schemaObj, reason));
+      prop = new PropScalar(parent, propName, 'JSON', Schemas.withJsonNote(context, schemaObj, reason));
     }
 
     // Cut only a real loop: a field pointing back to a type we already passed through. Compare the schema,

--- a/src/oas/nodes/get.ts
+++ b/src/oas/nodes/get.ts
@@ -77,12 +77,13 @@ export class Get extends Type implements Op {
     const summary = this.operation.getSummary();
     const originalPath = this.operation.path;
     const keep = context.generateOptions?.keepFieldNames === true;
-    const jsonReason = this.resultJsonReason(selection, keep);
+    const jsonReason = this.resultJsonReason(context, selection, keep);
+    const jsonNote = jsonReason ? Schemas.withJsonNote(context, {}, jsonReason).description : undefined;
     const paramsLine = this.paramsDocLine(context);
     const responseFieldsLine = this.responseFieldsDocLine(context, selection);
     const paginationLine = this.paginationDocLine(context);
 
-    if (description || summary || originalPath || jsonReason || paramsLine || responseFieldsLine || paginationLine) {
+    if (description || summary || originalPath || jsonNote || paramsLine || responseFieldsLine || paginationLine) {
       writer.write('  """\n').write('  ');
       if (description) {
         writer.write(description).write(' ');
@@ -93,8 +94,8 @@ export class Get extends Type implements Op {
       if (originalPath) {
         writer.write('(').write(originalPath).write(')');
       }
-      if (jsonReason) {
-        writer.write('\n\n  ').write(Schemas.withJsonNote({}, jsonReason).description!);
+      if (jsonNote) {
+        writer.write('\n\n  ').write(jsonNote);
       }
       if (paramsLine) {
         writer.write('\n\n  ').write(paramsLine);
@@ -130,9 +131,9 @@ export class Get extends Type implements Op {
   // always a Res wrapper (see res.ts); the real answer is one step in, at Res.response. #132
   //   e.g. (github) get:/watchers answers anyOf [array of user, array of watcher] — no shared
   //   fields, so getWatchers(): JSON gains a "NEEDS ATTENTION" note explaining why
-  protected resultJsonReason(selection: string[], keep: boolean): string | undefined {
+  protected resultJsonReason(context: OasContext, selection: string[], keep: boolean): string | undefined {
     const response = this.resultType instanceof Res ? this.resultType.response : this.resultType;
-    if (response instanceof Union) return response.emptyMergeReason(selection, keep);
+    if (response instanceof Union) return response.emptyMergeReason(context, selection, keep);
 
     if (response instanceof Scalar) return response.jsonReason;
 
@@ -335,7 +336,7 @@ export class Get extends Type implements Op {
       //   e.g. (world anvil) get:/manuscript 200: { description: ok }  — no `content` key   #147
       const reason = `the '${statusCode}' response declares no body — the real API may still return data this spec doesn't describe, so it's read as raw JSON instead of a fabricated empty result.`;
       warn(context, `  [${code}]`, reason);
-      const schema = Schemas.withJsonNote({}, reason);
+      const schema = Schemas.withJsonNote(context, {}, reason);
       // build the Res first so the Scalar below is parented to it from birth — building it the
       // other way round (Scalar as a constructor argument to `new Res(...)`) would parent it one
       // level too high, the same trap PropObj's own pre-built `obj` argument fell into.

--- a/src/oas/nodes/map.ts
+++ b/src/oas/nodes/map.ts
@@ -88,8 +88,11 @@ export class Map extends Type {
 
     // #132: same NEEDS ATTENTION note the rest of the schema gets when a field gives up on a real
     // type — here it sits above `value:` since a map's value has no field of its own to carry it.
-    if (this.valueJsonReason) {
-      writer.write('  """\n  ').write(Schemas.withJsonNote({}, this.valueJsonReason).description!).write('\n  """\n');
+    const valueNote = this.valueJsonReason
+      ? Schemas.withJsonNote(context, {}, this.valueJsonReason).description
+      : undefined;
+    if (valueNote) {
+      writer.write('  """\n  ').write(valueNote).write('\n  """\n');
     }
     writer.write('  value: ');
 

--- a/src/oas/nodes/param.ts
+++ b/src/oas/nodes/param.ts
@@ -69,8 +69,8 @@ export class Param extends Type {
     // Arguments sit in one comma-separated list, so the note is a quoted string right before the
     // name: `"NEEDS ATTENTION: ..." filter: JSON`. Block-quote only if the text needs it.
     const reason = this.jsonReason();
-    if (reason) {
-      const note = Schemas.withJsonNote({}, reason).description!;
+    const note = reason ? Schemas.withJsonNote(context, {}, reason).description : undefined;
+    if (note) {
       if (note.includes('\n') || note.includes('\r') || note.includes('"') || note.includes('\\')) {
         writer.write('"""\n').write(note).write('\n""" ');
       } else {

--- a/src/oas/nodes/post.ts
+++ b/src/oas/nodes/post.ts
@@ -74,11 +74,12 @@ export class Post extends Get {
     const summary = this.operation.getSummary();
     const originalPath = this.operation.path;
     const keep = context.generateOptions?.keepFieldNames === true;
-    const jsonReason = this.resultJsonReason(selection, keep);
+    const jsonReason = this.resultJsonReason(context, selection, keep);
+    const jsonNote = jsonReason ? Schemas.withJsonNote(context, {}, jsonReason).description : undefined;
     const paramsLine = this.paramsDocLine(context);
     const responseFieldsLine = this.responseFieldsDocLine(context, selection);
 
-    if (summary || originalPath || jsonReason || paramsLine || responseFieldsLine) {
+    if (summary || originalPath || jsonNote || paramsLine || responseFieldsLine) {
       writer.write('  """\n').write('  ');
       if (summary) {
         writer.write(summary).write(' ');
@@ -86,8 +87,8 @@ export class Post extends Get {
       if (originalPath) {
         writer.write('(').write(originalPath).write(')');
       }
-      if (jsonReason) {
-        writer.write('\n\n  ').write(Schemas.withJsonNote({}, jsonReason).description!);
+      if (jsonNote) {
+        writer.write('\n\n  ').write(jsonNote);
       }
       if (paramsLine) {
         writer.write('\n\n  ').write(paramsLine);

--- a/src/oas/nodes/propArray.ts
+++ b/src/oas/nodes/propArray.ts
@@ -108,7 +108,7 @@ export class PropArray extends Prop {
   //   e.g. (slack) archivedChannels gains a "NEEDS ATTENTION" note; a normal list doesn't.
   protected override effectiveDescription(context: OasContext): string | undefined {
     const reason = this.jsonReason(context);
-    return reason ? Schemas.withJsonNote(this.schema, reason).description : super.effectiveDescription(context);
+    return reason ? Schemas.withJsonNote(context, this.schema, reason).description : super.effectiveDescription(context);
   }
 
   dependencies(): IType[] {

--- a/src/oas/nodes/propObj.ts
+++ b/src/oas/nodes/propObj.ts
@@ -86,7 +86,7 @@ export class PropObj extends Prop {
   // e.g. (only-field-in-a-cycle) contributors gains a "NEEDS ATTENTION" note; createdDate doesn't.
   protected effectiveDescription(context: OasContext): string | undefined {
     const reason = this.jsonReason(context);
-    return reason ? Schemas.withJsonNote(this.schema, reason).description : super.effectiveDescription(context);
+    return reason ? Schemas.withJsonNote(context, this.schema, reason).description : super.effectiveDescription(context);
   }
 
   dependencies(context: OasContext): IType[] {

--- a/src/oas/nodes/res.ts
+++ b/src/oas/nodes/res.ts
@@ -69,7 +69,7 @@ export class Res extends Type {
         T.isScalar(response) ||
         response instanceof En ||
         (response instanceof Arr && response.itemsType instanceof Scalar) ||
-        (response instanceof Union && response.isFlat() && !response.hasSelectedProps(selection, keep))
+        (response instanceof Union && response.isFlat() && !response.hasSelectedProps(context, selection, keep))
       ) {
         // best attempt to just copy the value that comes out of the service. most likely the
         // value will have to be replaced by a GQL type. In fact, we could potentially use SYN_ here but

--- a/src/oas/nodes/union.ts
+++ b/src/oas/nodes/union.ts
@@ -150,7 +150,7 @@ export class Union extends Type {
       }
     } else if (context.inContextOf(Res, this)) {
       // a merge with no fields is never written — the field answers JSON instead  #80
-      if (this.isFlat() && !this.hasSelectedProps(selection, keep)) {
+      if (this.isFlat() && !this.hasSelectedProps(context, selection, keep)) {
         writer.write('JSON');
       } else {
         // R2: when promoted to an interface, the field returns the base interface, not the union name.
@@ -165,7 +165,7 @@ export class Union extends Type {
 
       if (this.isFlat()) {
         // an empty merge writes no type — its field was written as JSON  #80
-        if (!this.hasSelectedProps(selection, keep)) {
+        if (!this.hasSelectedProps(context, selection, keep)) {
           trace(context, '   [union::generate]', `[union] no fields to merge, skipping: ${this.name}`);
         }
         // No real union here: an input-position oneOf (GraphQL has no input unions) or no
@@ -185,7 +185,7 @@ export class Union extends Type {
         // `http_rule_response` is written as `HttpRuleResponse`. see docs/FIXED.md #43
         const filtered = this.selectedMembers(selection);
 
-        this.writeMemberJsonNote(writer);
+        this.writeMemberJsonNote(context, writer);
         writer
           .write('union ')
           .write(name)
@@ -220,7 +220,7 @@ export class Union extends Type {
     // `this.kind` (not a hardcoded 'type ') picks the keyword: 'type' for a response, 'input' for a
     // request body (body.ts). e.g. (r2-input-union-consolidated.yaml) POST /create's `oneOf` body
     // merges to one object — hardcoding 'type ' here would emit it as an invalid mutation argument.
-    this.writeMemberJsonNote(writer);
+    this.writeMemberJsonNote(context, writer);
     writer
       .write(this.kind + ' ')
       .write(name)
@@ -229,7 +229,7 @@ export class Union extends Type {
       .write(name)
       .write('\n');
 
-    for (const prop of this.dedupedSelectedProps(selection, keep)) {
+    for (const prop of this.dedupedSelectedProps(context, selection, keep)) {
       trace(context, '   [union::generate]', `-> property: ${prop.name} (parent: ${prop.parent!.name})`);
       prop.generate(context, writer, selection);
     }
@@ -246,7 +246,7 @@ export class Union extends Type {
   //   Individual: { status: { $ref: '#/…/IndividualStateType' } }   # enum
   //   PartyRole:  { status: { type: string } }
   // see docs/FIXED.md #39, #44
-  private dedupedSelectedProps(selection: string[], keep: boolean): Prop[] {
+  private dedupedSelectedProps(context: OasContext, selection: string[], keep: boolean): Prop[] {
     const kindOf = (prop: Prop) => prop.id.split(':')[1];
 
     const firstByName = new Map<string, Prop>();
@@ -274,7 +274,7 @@ export class Union extends Type {
         const reason =
           'different branches of a merged type declare this field differently, and no single GraphQL type fits both — sent as raw JSON.';
         warn(null, '[union]', reason);
-        return new PropScalar(prop.parent!, name, 'JSON', Schemas.withJsonNote({}, reason));
+        return new PropScalar(prop.parent!, name, 'JSON', Schemas.withJsonNote(context, {}, reason));
       }),
       keep,
     );
@@ -291,10 +291,11 @@ export class Union extends Type {
 
   // Writes a block-quoted note above the union/type line for every reason memberJsonReasons()
   // found; writes nothing when every member kept a real shape.
-  private writeMemberJsonNote(writer: Writer): void {
+  private writeMemberJsonNote(context: OasContext, writer: Writer): void {
     const reasons = this.memberJsonReasons();
     if (reasons.length === 0) return;
-    const note = Schemas.withJsonNote({}, reasons.join(' ')).description!;
+    const note = Schemas.withJsonNote(context, {}, reasons.join(' ')).description;
+    if (!note) return;
     writer.write('"""\n').write(note).write('\n"""\n');
   }
 
@@ -325,7 +326,7 @@ export class Union extends Type {
       // the writer emits — box collected enum WebLinkBaseType but wrote `type: FileBaseType!`. #57
       this.consolidateMembers(context, selection);
       const keep = context.generateOptions?.keepFieldNames === true;
-      return this.dedupedSelectedProps(selection, keep);
+      return this.dedupedSelectedProps(context, selection, keep);
     }
     // only members with a selected field are reachable (#26, #36); an allOf member also pulls in the
     // $ref base it extends — `Book: allOf [$ref Product, …]` -> Product (r2-interface-shared-base.yaml).
@@ -354,7 +355,7 @@ export class Union extends Type {
       return;
     }
 
-    for (const prop of this.dedupedSelectedProps(selection, keep)) {
+    for (const prop of this.dedupedSelectedProps(context, selection, keep)) {
       prop.select(context, writer, selection);
     }
 
@@ -526,19 +527,19 @@ export class Union extends Type {
   // False when merging finds no fields at all — such a union is written as JSON, not as an empty type.
   // Merged fields sit on this.props; the op line asks with no selection at hand, so read them first.
   // e.g. (github) get stargazers answers anyOf [array of simple-user, array of stargazer] — no fields  #80
-  public hasSelectedProps(selection: string[], keep: boolean): boolean {
+  public hasSelectedProps(context: OasContext, selection: string[], keep: boolean): boolean {
     if (this.consolidated) {
       return this.props.size > 0;
     }
-    return this.dedupedSelectedProps(selection, keep).length > 0;
+    return this.dedupedSelectedProps(context, selection, keep).length > 0;
   }
 
   // Why generate() above writes JSON instead of a real return type, or undefined if it doesn't.
   // The op's own docstring (get.ts/post.ts) reads this before this union writes anything. #132
   //   e.g. (github) get stargazers answers anyOf [array of simple-user, array of stargazer] — no
   //   fields to merge, so the operation answers JSON instead of an empty type
-  public emptyMergeReason(selection: string[], keep: boolean): string | undefined {
-    return this.isFlat() && !this.hasSelectedProps(selection, keep)
+  public emptyMergeReason(context: OasContext, selection: string[], keep: boolean): string | undefined {
+    return this.isFlat() && !this.hasSelectedProps(context, selection, keep)
       ? "this union merges every member's fields into one type, but none were selected — sent as raw JSON instead."
       : undefined;
   }

--- a/src/oas/oasContext.ts
+++ b/src/oas/oasContext.ts
@@ -71,6 +71,9 @@ export type GenerateOptions = {
   servicePrefix?: string; // prefix every type and root field with the service name
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;
+  // leave out the "NEEDS ATTENTION" note gen adds to every description it defaulted to JSON —
+  // for agent-facing SDL. warnings are always logged regardless.
+  skipDegradeReasons?: boolean;
   skipAuth?: boolean;
   authValuePrefix?: string; // text written before an apiKey header value
   directives?: DirectivesConfig; // directives to apply

--- a/src/oas/oasGen.ts
+++ b/src/oas/oasGen.ts
@@ -96,6 +96,7 @@ interface IGenOptions {
   servicePrefix?: string;
   inferEntityResolvers?: boolean;
   emitConnectorErrors?: boolean;
+  skipDegradeReasons?: boolean;
   skipAuth?: boolean;
   authValuePrefix?: string;
   directives?: DirectivesConfig;

--- a/src/oas/utils/schemas.ts
+++ b/src/oas/utils/schemas.ts
@@ -98,12 +98,15 @@ export class Schemas {
   }
 
   // Marks a schema about to fall back to JSON, so the reason lands in the SDL, not just the console
-  // log. e.g. (docker-engine) Labels: { additionalProperties: { type: string } } in a request body
-  // -> `labels: JSON` gets a "NEEDS ATTENTION: ..." docstring. see docs/FIXED.md #133, #152
-  public static withJsonNote(schema: SchemaObject, reason: string): SchemaObject {
+  // log, unless `skipDegradeReasons` asks for agent-facing SDL with no note. e.g. (docker-engine)
+  // Labels: { additionalProperties: { type: string } } -> `labels: JSON` gets the docstring.
+  public static withJsonNote(context: OasContext, schema: SchemaObject, reason: string): SchemaObject {
+    const description = schema.description && Schemas.asciiSafeDashes(schema.description);
+    if (context.generateOptions?.skipDegradeReasons === true) {
+      return description ? { ...schema, description } : schema;
+    }
     const note = Schemas.asciiSafeDashes(`NEEDS ATTENTION: ${reason}`);
-    const description = schema.description ? `${Schemas.asciiSafeDashes(schema.description)}\n\n${note}` : note;
-    return { ...schema, description };
+    return { ...schema, description: description ? `${description}\n\n${note}` : note };
   }
 
   // Writes one parameter's default, minimum, maximum, and allowed values as plain words for the

--- a/src/tests/runners.ts
+++ b/src/tests/runners.ts
@@ -38,6 +38,7 @@ export async function runOasTest(
     federationVersion?: string;
     composeFederationVersion?: string;
     emitConnectorErrors?: boolean;
+    skipDegradeReasons?: boolean;
     skipAuth?: boolean;
     authValuePrefix?: string;
     directives?: DirectivesConfig;
@@ -69,6 +70,7 @@ export async function runOasTest(
     docPagination: opts.docPagination,
     inferEntityResolvers: opts.inferEntityResolvers,
     emitConnectorErrors: opts.emitConnectorErrors,
+    skipDegradeReasons: opts.skipDegradeReasons,
     skipAuth: opts.skipAuth,
     authValuePrefix: opts.authValuePrefix,
     connectorSpecVersion: opts.connectorSpecVersion,

--- a/tests/all/degrade-reasons.test.ts
+++ b/tests/all/degrade-reasons.test.ts
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { runOasTest } from '../../src/tests/runners.js';
+import './_setup.js';
+
+// #188: "NEEDS ATTENTION: ... defaulted to JSON" notes are addressed to the schema author, but
+// they ride field descriptions into the SDL every consumer (human or agent) reads, diluting the
+// description they sit next to. skipDegradeReasons drops the generated note; the author's own
+// text (dash-normalised) always survives, even when it happens to contain the literal words
+// "NEEDS ATTENTION:" itself. Off by default: the SDL stays byte-identical without the flag.
+
+// The fixture has fields that default to JSON in every emission shape: docstring-form (with and
+// without an author description), an argument-form note, and two fields whose own author text
+// already contains "NEEDS ATTENTION:" and an em-dash, to prove the flag never touches author text.
+const PATHS = ['get:/things', 'get:/things/{thing_id}'];
+
+const run = (opts: { skipDegradeReasons?: boolean } = {}) =>
+  runOasTest('degrade-reasons.yaml', PATHS, 2, 1, { skipValidation: true, ...opts });
+
+const DEFAULT_SCHEMA = `extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.14", import: ["@key"])
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.4"
+    import: ["@connect", "@source"]
+  )
+  @source(name: "api", http: { baseURL: "http://localhost:9000" })
+
+
+scalar JSON
+
+type Thing {
+  "NEEDS ATTENTION: this field's shape didn't match any known pattern and defaulted to JSON -- worth checking the source OAS schema."
+  bareBlob: JSON
+  """
+  An opaque blob.
+
+NEEDS ATTENTION: this field's shape didn't match any known pattern and defaulted to JSON -- worth checking the source OAS schema.
+  """
+  blob: JSON
+  """
+  Uses an em--dash in its own text.
+
+NEEDS ATTENTION: this field's shape didn't match any known pattern and defaulted to JSON -- worth checking the source OAS schema.
+  """
+  emDash: JSON
+  """
+  Author note: NEEDS ATTENTION: check this value by hand.
+
+NEEDS ATTENTION: this field's shape didn't match any known pattern and defaulted to JSON -- worth checking the source OAS schema.
+  """
+  literalNote: JSON
+  thingId: Int
+}
+
+type Query {
+  """
+  List things (/things)
+  """
+  things("NEEDS ATTENTION: this object declares no properties of its own -- sent as raw JSON instead." filter: JSON): [Thing]
+    @connect(
+      source: "api"
+      http: {
+        GET: "/things"
+        queryParams: """
+          $args {
+            "filter": filter
+          }
+        """
+      }
+      selection: """
+      bareBlob: bare_blob?
+      blob?
+      emDash: em_dash?
+      literalNote: literal_note?
+      thingId: thing_id?
+      """
+    )
+  """
+  Get a thing (/things/{thing_id})
+  """
+  thingsByThingId(thingId: Int!): Thing
+    @connect(
+      source: "api"
+      http: { GET: "/things/{$args.thingId}"}
+      selection: """
+      bareBlob: bare_blob?
+      blob?
+      emDash: em_dash?
+      literalNote: literal_note?
+      thingId: thing_id?
+      """
+    )
+}
+
+`;
+
+const SKIPPED_SCHEMA = `extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.14", import: ["@key"])
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.4"
+    import: ["@connect", "@source"]
+  )
+  @source(name: "api", http: { baseURL: "http://localhost:9000" })
+
+
+scalar JSON
+
+type Thing {
+  bareBlob: JSON
+  "An opaque blob."
+  blob: JSON
+  "Uses an em--dash in its own text."
+  emDash: JSON
+  "Author note: NEEDS ATTENTION: check this value by hand."
+  literalNote: JSON
+  thingId: Int
+}
+
+type Query {
+  """
+  List things (/things)
+  """
+  things(filter: JSON): [Thing]
+    @connect(
+      source: "api"
+      http: {
+        GET: "/things"
+        queryParams: """
+          $args {
+            "filter": filter
+          }
+        """
+      }
+      selection: """
+      bareBlob: bare_blob?
+      blob?
+      emDash: em_dash?
+      literalNote: literal_note?
+      thingId: thing_id?
+      """
+    )
+  """
+  Get a thing (/things/{thing_id})
+  """
+  thingsByThingId(thingId: Int!): Thing
+    @connect(
+      source: "api"
+      http: { GET: "/things/{$args.thingId}"}
+      selection: """
+      bareBlob: bare_blob?
+      blob?
+      emDash: em_dash?
+      literalNote: literal_note?
+      thingId: thing_id?
+      """
+    )
+}
+
+`;
+
+test('test_188_notes_stay_by_default', async () => {
+  const schema = await run();
+  assert.strictEqual(schema, DEFAULT_SCHEMA, 'default output is byte-identical to before the flag existed');
+});
+
+test('test_188_skip_degrade_reasons_drops_every_generated_note', async () => {
+  const schema = await run({ skipDegradeReasons: true });
+  assert.strictEqual(schema, SKIPPED_SCHEMA, 'no generated note anywhere, author text (incl. its own "NEEDS ATTENTION:") survives');
+});

--- a/tests/resources/oas/degrade-reasons.yaml
+++ b/tests/resources/oas/degrade-reasons.yaml
@@ -1,0 +1,72 @@
+openapi: 3.0.0
+info:
+  title: Strip JSON diagnostics
+  version: 1.0.0
+servers:
+  - url: http://localhost:9000
+paths:
+  /things:
+    get:
+      operationId: listThings
+      summary: List things
+      parameters:
+        - name: filter
+          in: query
+          schema:
+            # no type/oneOf/allOf/properties: the catch-all JSON fallback + argument-form note
+            example: anything
+      responses:
+        '200':
+          description: things
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Thing' }
+  /things/{thing_id}:
+    get:
+      operationId: getThing
+      summary: Get a thing
+      parameters:
+        - name: thing_id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: one thing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Thing' }
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        thing_id: { type: integer }
+        blob:
+          description: An opaque blob.
+          anyOf:
+            - type: string
+            - type: integer
+            - type: number
+        bare_blob:
+          # no description: the note becomes the field's whole single-line docstring
+          anyOf:
+            - type: string
+            - type: integer
+            - type: number
+        literal_note:
+          # the author's own text already contains "NEEDS ATTENTION:" -- must survive skipDegradeReasons verbatim
+          description: 'Author note: NEEDS ATTENTION: check this value by hand.'
+          anyOf:
+            - type: string
+            - type: integer
+            - type: number
+        em_dash:
+          # the author's own text carries a real em-dash (U+2014) -- normalised to "--" either way
+          description: 'Uses an em—dash in its own text.'
+          anyOf:
+            - type: string
+            - type: integer
+            - type: number


### PR DESCRIPTION
Supersedes #13 and keeps its fixture and tests.
Gates the note at the producer instead of a text pass.
FIXED.md #188.